### PR TITLE
fix: FINC-2981 remove unnecessary git push from npm package process

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,10 +41,3 @@ jobs:
         npm publish --ignore-scripts
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    # push the version changes to GitHub
-    - run: git push
-      env:
-        # The secret is passed automatically. Nothing to configure.
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-
-


### PR DESCRIPTION
Removes the git push from our npm package process as we don't actually need the version in the repository itself as it will be correctly updated and sent to npm on build (based on the tag provided).